### PR TITLE
Don't override user config in dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,11 +63,15 @@ module.exports = (env, argv) => {
     config.devtool = "source-map";
     config.watch = true;
     config.entry.unshift("webpack/hot/poll?100");
+    
+    config.plugins.push(new CopyPlugin([
+      { from: 'static', to: 'static', ignore: ['config/config.toml'] },
+    ]),)
+  } else {
+    config.plugins.push(new CopyPlugin([
+      { from: 'static', to: 'static' },
+    ]),)
   }
-
-  config.plugins.push(new CopyPlugin([
-    { from: 'static', to: 'static' },
-  ]),)
 
   config.plugins.push(new CleanWebpackPlugin({
     cleanOnceBeforeBuildPatterns: ["**/*", "!static/**"],


### PR DESCRIPTION
As for now on each yarn dev run webpack overrides user config. Suggestion to not override it while in dev mode.
@tadaskay