### PR TITLE
Release application after tagging

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on: [pull_request, push]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Lint
+        run: yarn lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    # If the commit is tagged with a version (e.g. "1.0.0") release the app after building
+    tags: ["*"]
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    # Platforms to build on/for
+    strategy:
+      matrix:
+        os: [macos-10.15]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Read version from tag
+        id: get_version
+        uses: battila7/get-version-action@v1.2.1
+      - name: Replace version
+        run: yarn version --new-version ${{ steps.get_version.outputs.version }}
+
+      - name: Release app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          build_script_name: "build"
+          release: true
+          github_token: ${{ secrets.github_token }}
+          # macOS code signing certificate
+          mac_certs: ${{ secrets.mac_certs }}
+          mac_certs_password: ${{ secrets.mac_certs_password }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mysterium-vpn-desktop
 
 [![Github All Releases](https://img.shields.io/github/downloads/mysteriumnetwork/mysterium-vpn-desktop/total.svg)](https://github.com/mysteriumnetwork/mysterium-vpn-desktop/releases)
+![Lint](https://github.com/mysteriumnetwork/mysterium-vpn-desktop/workflows/Lint/badge.svg?event=push)
 
 **Work in progress: use with care**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mysterium-vpn-desktop",
   "productName": "MysteriumVPN",
-  "version": "2.0.0-beta1-next",
+  "version": "0.0.0-snapshot",
   "main": "index.js",
   "author": {
     "name": "Mysterium Network",
@@ -86,7 +86,13 @@
   "build": {
     "appId": "network.mysterium.mysterium-vpn-desktop",
     "mac": {
+      "target": "dmg",
       "icon": "static/logo.icns"
+    },
+    "publish": {
+      "provider": "github",
+      "releaseType":  "prerelease",
+      "vPrefixedTagName": false
     }
   }
 }


### PR DESCRIPTION
Closes: https://github.com/mysteriumnetwork/node/issues/2190

Implemented workflow:
- Releases should drafted from Github
- CI is marking package.json version from inputed release version