### PR TITLE
Focus current windows if user is trying to open another one

### DIFF
--- a/src/views/common/Loading/loading-view.tsx
+++ b/src/views/common/Loading/loading-view.tsx
@@ -8,7 +8,7 @@ import React from "react"
 import styled from "styled-components"
 
 import welcomeBg from "../../../ui-kit/assets/welcome-bg.png"
-import { Spinner } from "../../../ui-kit/components/Spinner/spinner"
+import { Spinner } from "../../../ui-kit/components/Spinner/Spinner"
 
 const Container = styled.div`
     background: url(${welcomeBg}) no-repeat, #8e3061;


### PR DESCRIPTION
The solution comes from the docs: https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock

Tested this on linux. Seems to work. Instead of starting a new application, it now focuses currently running one.
It would be great if someone tested on mac or windows.

Closes: https://github.com/mysteriumnetwork/node/issues/3041