### PR TITLE
Show window if opened again while in tray

### DIFF
--- a/src/main/index.tsx
+++ b/src/main/index.tsx
@@ -171,7 +171,7 @@ if (!appInstanceLock) {
         // Someone tried to run a second instance, we should focus our window.
         if (win) {
             if (win.isMinimized()) win.restore()
-            win.focus()
+            win.show()
         }
     })
 


### PR DESCRIPTION
If you closed the window instead of minimizing it, it would go to the system tray, opening the app again would not bring it to focus.
This should now be fixed.

I've tested this on Linux, it's working, if someone could test on windows that would be great,  [apparently it should work](https://github.com/mysteriumnetwork/mysterium-vpn-desktop/pull/88/files#r566724484)

Close: https://github.com/mysteriumnetwork/node/issues/3066