### PR TITLE
Move identity (account) to Settings/Account

### DIFF
--- a/src/navigation/locations.ts
+++ b/src/navigation/locations.ts
@@ -131,6 +131,10 @@ export const locations = {
         path: "/settings/connection",
         title: "Settings/Connection",
     },
+    settingsAccount: {
+        path: "/settings/account",
+        title: "Settings/Account",
+    },
 }
 
 export const locationByPath = (path: string): AppLocation | undefined =>

--- a/src/views/common/Settings/SettingsAccount.tsx
+++ b/src/views/common/Settings/SettingsAccount.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2021 BlockDev AG
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { observer } from "mobx-react-lite"
+import React from "react"
+import styled from "styled-components"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faFileExport, faIdBadge } from "@fortawesome/free-solid-svg-icons"
+
+import { Heading2, Small } from "../../../ui-kit/typography"
+import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
+import { useStores } from "../../../store"
+import { LightButton } from "../../../ui-kit/components/Button/LightButton"
+import { TextInput } from "../../../ui-kit/form-components/TextInput"
+
+const Title = styled(Heading2)`
+    margin-bottom: 15px;
+`
+
+const Section = styled(ViewContent)`
+    padding: 20px;
+    margin-bottom: 10px;
+`
+
+const SectionIcon = styled(FontAwesomeIcon)`
+    margin-bottom: 15px;
+`
+
+const Explanation = styled(Small)`
+    opacity: 0.5;
+    margin-bottom: 15px;
+`
+
+export const SettingsAccount: React.FC = observer(() => {
+    const { payment, identity } = useStores()
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const onBackupIdentity = () => {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const onRestoreIdentity = () => {}
+    return (
+        <>
+            <Section>
+                <SectionIcon icon={faIdBadge} color="#ffffff88" size="2x" />
+                <Title>Identity ({identity.identity?.registrationStatus})</Title>
+                <Explanation>
+                    Identity is your Mysterium internal user ID. Never send ether or any kind of ERC20 tokens there.
+                </Explanation>
+                <TextInput disabled value={identity.identity?.id} />
+            </Section>
+            <Section>
+                <SectionIcon icon={faFileExport} color="#ffffff88" size="2x" />
+                <Title>Backup/Restore</Title>
+                <Explanation>
+                    We don&apos;t store any account data. Make sure to back up your private key to keep your{" "}
+                    {payment.appCurrency}s safe.
+                </Explanation>
+                <div>
+                    <LightButton style={{ marginRight: 20 }} onClick={() => onBackupIdentity()}>
+                        Backup
+                    </LightButton>
+                    <LightButton onClick={() => onRestoreIdentity()}>Restore from backup</LightButton>
+                </div>
+            </Section>
+        </>
+    )
+})

--- a/src/views/common/Settings/SettingsFilters.tsx
+++ b/src/views/common/Settings/SettingsFilters.tsx
@@ -21,7 +21,7 @@ const Title = styled(Heading2)`
 `
 
 const Section = styled(ViewContent)`
-    padding: 20px 26px;
+    padding: 20px;
     margin-bottom: 10px;
 `
 

--- a/src/views/common/Settings/SettingsView.tsx
+++ b/src/views/common/Settings/SettingsView.tsx
@@ -9,7 +9,7 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { Redirect, Route, Switch } from "react-router-dom"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faGlobe, faSlidersH } from "@fortawesome/free-solid-svg-icons"
+import { faGlobe, faSlidersH, faUserAlt } from "@fortawesome/free-solid-svg-icons"
 
 import { Heading2 } from "../../../ui-kit/typography"
 import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
@@ -25,6 +25,7 @@ import { AppVersion } from "../../../daemon/components/AppVersion"
 
 import { SettingsFilters } from "./SettingsFilters"
 import { SettingsConnection } from "./SettingsConnection"
+import { SettingsAccount } from "./SettingsAccount"
 
 const SideTop = styled.div`
     box-sizing: border-box;
@@ -90,6 +91,7 @@ export const SettingsView: React.FC = observer(() => {
     const { router } = useStores()
     const isFilterTabActive = router.location.pathname.includes(locations.settingsFilters.path)
     const isConnectionTabActive = router.location.pathname.includes(locations.settingsConnection.path)
+    const isAccountTabActive = router.location.pathname.includes(locations.settingsAccount.path)
     return (
         <ViewContainer>
             <ViewNavBar />
@@ -111,6 +113,10 @@ export const SettingsView: React.FC = observer(() => {
                             <FontAwesomeIcon icon={faGlobe} />
                             Connection
                         </NavButton>
+                        <NavButton active={isAccountTabActive} onClick={() => router.push(locations.settingsAccount)}>
+                            <FontAwesomeIcon icon={faUserAlt} />
+                            Account
+                        </NavButton>
                         <Version />
                     </SideBot>
                 </ViewSidebar>
@@ -121,6 +127,9 @@ export const SettingsView: React.FC = observer(() => {
                         </Route>
                         <Route exact path={locations.settingsConnection.path}>
                             <SettingsConnection />
+                        </Route>
+                        <Route exact path={locations.settingsAccount.path}>
+                            <SettingsAccount />
                         </Route>
                         <Redirect to={locations.settingsFilters.path} />
                     </Switch>

--- a/src/views/consumer/Wallet/WalletIdentity.tsx
+++ b/src/views/consumer/Wallet/WalletIdentity.tsx
@@ -6,44 +6,7 @@
  */
 import { observer } from "mobx-react-lite"
 import React from "react"
-import styled from "styled-components"
-
-import { Paragraph, Small } from "../../../ui-kit/typography"
-import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
-import { IconIdentity } from "../../../ui-kit/icons/IconIdentity"
-import { brandLight } from "../../../ui-kit/colors"
-import { TextInput } from "../../../ui-kit/form-components/TextInput"
-import { useStores } from "../../../store"
-
-const Content = styled(ViewContent)`
-    padding: 20px 26px;
-`
-
-const SectionTitle = styled(Paragraph)`
-    margin-top: 13px;
-    height: 28px;
-`
-const Explanation = styled(Small)`
-    opacity: 0.5;
-    margin-bottom: 15px;
-`
-
-const SectionIconWrap = styled.div`
-    margin-bottom: 15px;
-`
 
 export const WalletIdentity: React.FC = observer(() => {
-    const { identity } = useStores()
-    return (
-        <Content>
-            <SectionIconWrap>
-                <IconIdentity color={brandLight} />
-            </SectionIconWrap>
-            <SectionTitle>Identity: {identity.identity?.registrationStatus}</SectionTitle>
-            <Explanation>
-                Identity is your Mysterium internal user ID. Never send ether or any kind of ERC20 tokens there.
-            </Explanation>
-            <TextInput disabled value={identity.identity?.id} />
-        </Content>
-    )
+    return <div />
 })


### PR DESCRIPTION
Motivation is to have ID away from the wallet so there's lesser chance of users accidentally sending tokens to the address and losing them forever.

Closes: #156 
