### PR TITLE
MYST on eth chain only note when topping up

### DIFF
--- a/src/app/onboarding/components/IntroductionSteps/IntroductionSteps.tsx
+++ b/src/app/onboarding/components/IntroductionSteps/IntroductionSteps.tsx
@@ -241,7 +241,7 @@ export const IntroductionSteps: React.FC = observer(() => {
                                 renderer="svg"
                             />
                         </Animation>
-                        <Subtitle>BTC, ETH, LTC, BTH and more</Subtitle>
+                        <Subtitle>BTC, ETH, LTC, BCH and more</Subtitle>
                         <Description>
                             Top up your account now or do it later and use limited functionality and free nodes
                         </Description>

--- a/src/app/views/consumer/Topup/coingate/CoingateSelectCurrency.tsx
+++ b/src/app/views/consumer/Topup/coingate/CoingateSelectCurrency.tsx
@@ -120,7 +120,7 @@ export const CoingateSelectCurrency: React.FC = observer(() => {
                     <SideTop>
                         <IconWallet color={brandLight} />
                         <Title>Top up your account</Title>
-                        <TitleDescription>Select the cryptocurrency in which the top-up will be done</TitleDescription>
+                        <TitleDescription>Select the cryptocurrency in which the top-up will be done. MYST is currently only supported on the Ethereum network!</TitleDescription>
                     </SideTop>
                     <SideBot>
                         <AmountSelect>


### PR DESCRIPTION
Users need to be aware that MYST is only supported on the Ethereum network, very likely to have Polygon deposit attempts made with users losing funds.