### PR TITLE
Replace Backup Later with Go Back

### DIFF
--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -18,7 +18,7 @@ import { ViewSidebar } from "../../../navigation/components/ViewSidebar/ViewSide
 import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
 import { ViewNavBar } from "../../../navigation/components/ViewNavBar/ViewNavBar"
 import { Heading2, Small } from "../../../ui-kit/typography"
-import { ButtonContent, ButtonIcon, PrimarySidebarActionButton} from "../../../ui-kit/components/Button/SidebarButtons"
+import { ButtonContent, ButtonIcon, PrimarySidebarActionButton } from "../../../ui-kit/components/Button/SidebarButtons"
 import { useStores } from "../../../store"
 import { ExportIdentityFormFields, ExportIdentityPrompt } from "../../../views/common/Settings/ExportIdentityPrompt"
 import { brandLight } from "../../../ui-kit/colors"
@@ -68,7 +68,7 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
         onboarding.finishIDSetup()
     }
     // const handleBackupLater = () => {
-        // nextStep()
+    // nextStep()
     // }
 
     const [exportPrompt, setExportPrompt] = useState(false)

--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -6,7 +6,7 @@
  */
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
-import { faArrowAltCircleLeft, faClock, faFileExport } from "@fortawesome/free-solid-svg-icons"
+import { faFileExport } from "@fortawesome/free-solid-svg-icons"
 import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import Lottie from "react-lottie-player"
@@ -21,8 +21,7 @@ import { Heading2, Small } from "../../../ui-kit/typography"
 import {
     ButtonContent,
     ButtonIcon,
-    PrimarySidebarActionButton,
-    SecondarySidebarActionButton,
+    PrimarySidebarActionButton
 } from "../../../ui-kit/components/Button/SidebarButtons"
 import { useStores } from "../../../store"
 import { ExportIdentityFormFields, ExportIdentityPrompt } from "../../../views/common/Settings/ExportIdentityPrompt"

--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -72,9 +72,9 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
     const nextStep = () => {
         onboarding.finishIDSetup()
     }
-    const handleBackupLater = () => {
-        nextStep()
-    }
+    // const handleBackupLater = () => {
+    //     nextStep()
+    // }
 
     const [exportPrompt, setExportPrompt] = useState(false)
     const handleBackupNow = () => {
@@ -121,7 +121,7 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
                                 Backup Private Key
                             </ButtonContent>
                         </PrimarySidebarActionButton>
-                        <SecondarySidebarActionButton onClick={handleBackupLater}>
+                        <SecondarySidebarActionButton>
                             <ButtonContent>
                                 <ButtonIcon>
                                     <FontAwesomeIcon icon={faClock} />

--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -19,7 +19,12 @@ import { ViewSidebar } from "../../../navigation/components/ViewSidebar/ViewSide
 import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
 import { ViewNavBar } from "../../../navigation/components/ViewNavBar/ViewNavBar"
 import { Heading2, Small } from "../../../ui-kit/typography"
-import { ButtonContent, ButtonIcon, PrimarySidebarActionButton, SecondarySidebarActionButton } from "../../../ui-kit/components/Button/SidebarButtons"
+import {
+    ButtonContent,
+    ButtonIcon,
+    PrimarySidebarActionButton,
+    SecondarySidebarActionButton,
+} from "../../../ui-kit/components/Button/SidebarButtons"
 import { useStores } from "../../../store"
 import { ExportIdentityFormFields, ExportIdentityPrompt } from "../../../views/common/Settings/ExportIdentityPrompt"
 import { brandLight } from "../../../ui-kit/colors"

--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -6,11 +6,12 @@
  */
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
-import { faFileExport } from "@fortawesome/free-solid-svg-icons"
+import { faFileExport, faArrowAltCircleLeft } from "@fortawesome/free-solid-svg-icons"
 import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import Lottie from "react-lottie-player"
 import toast from "react-hot-toast"
+import { useNavigate } from "react-router-dom"
 
 import { ViewContainer } from "../../../navigation/components/ViewContainer/ViewContainer"
 import { ViewSplit } from "../../../navigation/components/ViewSplit/ViewSplit"
@@ -18,7 +19,7 @@ import { ViewSidebar } from "../../../navigation/components/ViewSidebar/ViewSide
 import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
 import { ViewNavBar } from "../../../navigation/components/ViewNavBar/ViewNavBar"
 import { Heading2, Small } from "../../../ui-kit/typography"
-import { ButtonContent, ButtonIcon, PrimarySidebarActionButton } from "../../../ui-kit/components/Button/SidebarButtons"
+import { ButtonContent, ButtonIcon, PrimarySidebarActionButton, SecondarySidebarActionButton } from "../../../ui-kit/components/Button/SidebarButtons"
 import { useStores } from "../../../store"
 import { ExportIdentityFormFields, ExportIdentityPrompt } from "../../../views/common/Settings/ExportIdentityPrompt"
 import { brandLight } from "../../../ui-kit/colors"
@@ -64,12 +65,10 @@ const Content = styled(ViewContent)`
 export const IdentityBackup: React.FC = observer(function IdentityBackup() {
     const { onboarding, identity } = useStores()
 
+    const navigate = useNavigate()
     const nextStep = () => {
         onboarding.finishIDSetup()
     }
-    // const handleBackupLater = () => {
-    // nextStep()
-    // }
 
     const [exportPrompt, setExportPrompt] = useState(false)
     const handleBackupNow = () => {
@@ -116,14 +115,14 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
                                 Backup Private Key
                             </ButtonContent>
                         </PrimarySidebarActionButton>
-                        {/* <SecondarySidebarActionButton>
+                        <SecondarySidebarActionButton onClick={() => navigate(-1)}>
                             <ButtonContent>
                                 <ButtonIcon>
                                     <FontAwesomeIcon icon={faArrowAltCircleLeft} />
                                 </ButtonIcon>
                                 Go Back
                             </ButtonContent>
-                        </SecondarySidebarActionButton> */}
+                        </SecondarySidebarActionButton>
                     </SideBot>
                 </ViewSidebar>
                 <Content>

--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -18,11 +18,7 @@ import { ViewSidebar } from "../../../navigation/components/ViewSidebar/ViewSide
 import { ViewContent } from "../../../navigation/components/ViewContent/ViewContent"
 import { ViewNavBar } from "../../../navigation/components/ViewNavBar/ViewNavBar"
 import { Heading2, Small } from "../../../ui-kit/typography"
-import {
-    ButtonContent,
-    ButtonIcon,
-    PrimarySidebarActionButton
-} from "../../../ui-kit/components/Button/SidebarButtons"
+import { ButtonContent, ButtonIcon, PrimarySidebarActionButton} from "../../../ui-kit/components/Button/SidebarButtons"
 import { useStores } from "../../../store"
 import { ExportIdentityFormFields, ExportIdentityPrompt } from "../../../views/common/Settings/ExportIdentityPrompt"
 import { brandLight } from "../../../ui-kit/colors"
@@ -74,8 +70,6 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
     // const handleBackupLater = () => {
         // nextStep()
     // }
-
-    
 
     const [exportPrompt, setExportPrompt] = useState(false)
     const handleBackupNow = () => {

--- a/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
+++ b/src/app/onboarding/components/IdentityBackup/IdentityBackup.tsx
@@ -6,7 +6,7 @@
  */
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
-import { faClock, faFileExport } from "@fortawesome/free-solid-svg-icons"
+import { faArrowAltCircleLeft, faClock, faFileExport } from "@fortawesome/free-solid-svg-icons"
 import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import Lottie from "react-lottie-player"
@@ -73,8 +73,10 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
         onboarding.finishIDSetup()
     }
     // const handleBackupLater = () => {
-    //     nextStep()
+        // nextStep()
     // }
+
+    
 
     const [exportPrompt, setExportPrompt] = useState(false)
     const handleBackupNow = () => {
@@ -121,14 +123,14 @@ export const IdentityBackup: React.FC = observer(function IdentityBackup() {
                                 Backup Private Key
                             </ButtonContent>
                         </PrimarySidebarActionButton>
-                        <SecondarySidebarActionButton>
+                        {/* <SecondarySidebarActionButton>
                             <ButtonContent>
                                 <ButtonIcon>
-                                    <FontAwesomeIcon icon={faClock} />
+                                    <FontAwesomeIcon icon={faArrowAltCircleLeft} />
                                 </ButtonIcon>
-                                Backup later
+                                Go Back
                             </ButtonContent>
-                        </SecondarySidebarActionButton>
+                        </SecondarySidebarActionButton> */}
                     </SideBot>
                 </ViewSidebar>
                 <Content>


### PR DESCRIPTION
Remove the option for users to skip the important step of properly backing up their Mysterium ID and balance. 

Avoiding loss of funds, at times instant loss of funds, if something happens where users delete reinstall the app without back up. Furthermore, facilitating the account recovery process in case of a potential top up fail.