### PR TITLE
Add/Replace "Use a Referral Code" button with "Go Back"

### DIFF
--- a/src/app/onboarding/components/InitialTopup/InitialTopup.tsx
+++ b/src/app/onboarding/components/InitialTopup/InitialTopup.tsx
@@ -6,12 +6,13 @@
  */
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
-import { faUserFriends, faWallet } from "@fortawesome/free-solid-svg-icons"
+import { faWallet, faArrowAltCircleLeft } from "@fortawesome/free-solid-svg-icons"
 import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import Lottie from "react-lottie-player"
 import { comparer, reaction } from "mobx"
 import { IdentityRegistrationStatus } from "mysterium-vpn-js"
+import { useNavigate } from "react-router-dom"
 
 import { ViewContainer } from "../../../navigation/components/ViewContainer/ViewContainer"
 import { ViewSplit } from "../../../navigation/components/ViewSplit/ViewSplit"
@@ -70,15 +71,16 @@ const Content = styled(ViewContent)`
 
 export const InitialTopup: React.FC = observer(function InitialTopup() {
     const root = useStores()
+    const navigate = useNavigate()
     const { payment, onboarding, identity } = root
 
     const handleTopupNow = async () => {
         return payment.startTopupFlow(locations.onboardingWalletTopup)
     }
     const [referralPrompt, setReferralPrompt] = useState(false)
-    const handleUseReferralCode = () => {
-        setReferralPrompt(true)
-    }
+    // const handleUseReferralCode = () => {
+    //     setReferralPrompt(true)
+    // }
     const handleReferralSubmit = async ({ code }: ReferralCodeFormFields) => {
         setReferralPrompt(false)
         await onboarding.registerWithReferralCode(code)
@@ -123,12 +125,20 @@ export const InitialTopup: React.FC = observer(function InitialTopup() {
                                 Top up now
                             </ButtonContent>
                         </PrimarySidebarActionButton>
-                        <SecondarySidebarActionButton onClick={handleUseReferralCode}>
+                        {/* <SecondarySidebarActionButton onClick={handleUseReferralCode}>
                             <ButtonContent>
                                 <ButtonIcon>
                                     <FontAwesomeIcon icon={faUserFriends} />
                                 </ButtonIcon>
                                 Use a Referral code
+                            </ButtonContent>
+                        </SecondarySidebarActionButton> */}
+                        <SecondarySidebarActionButton onClick={() => navigate(-1)}>
+                            <ButtonContent>
+                                <ButtonIcon>
+                                    <FontAwesomeIcon icon={faArrowAltCircleLeft} />
+                                </ButtonIcon>
+                                Go Back
                             </ButtonContent>
                         </SecondarySidebarActionButton>
                     </SideBot>

--- a/src/app/onboarding/components/InitialTopup/InitialTopup.tsx
+++ b/src/app/onboarding/components/InitialTopup/InitialTopup.tsx
@@ -125,14 +125,6 @@ export const InitialTopup: React.FC = observer(function InitialTopup() {
                                 Top up now
                             </ButtonContent>
                         </PrimarySidebarActionButton>
-                        {/* <SecondarySidebarActionButton onClick={handleUseReferralCode}>
-                            <ButtonContent>
-                                <ButtonIcon>
-                                    <FontAwesomeIcon icon={faUserFriends} />
-                                </ButtonIcon>
-                                Use a Referral code
-                            </ButtonContent>
-                        </SecondarySidebarActionButton> */}
                         <SecondarySidebarActionButton onClick={() => navigate(-1)}>
                             <ButtonContent>
                                 <ButtonIcon>


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently, users have been asking us about our Referral Code but we do not have any active referral codes. Also when you reach "Your Identity" page, there is no way to go back. 

**Describe the solution you'd like**
My suggestion would be to enable users the possibility of going back to previous pages without having to manually delete user data on terminal and reboot the app.  


**Describe alternatives you've considered**
Either replacing "Use a Referral Code" button with "Go Back" button, just like it was added on previous "Identity Backup" page. E.G. https://github.com/mysteriumnetwork/mysterium-vpn-desktop/pull/406

or

Adding an extra "Go Back" button to the page. Leaving it with three buttons instead of two. 

How it is displayed right now:
<img width="632" alt="Screenshot 2022-11-05 at 16 56 47" src="https://user-images.githubusercontent.com/84313603/200138616-3041fd06-6323-41b4-94b8-272d553d7f6d.png">

Solution:
<img width="633" alt="Screenshot 2022-11-05 at 16 45 13" src="https://user-images.githubusercontent.com/84313603/200138582-35b6e90b-d8a3-4a2c-9237-918925a52e06.png">





