### PR TITLE
Change-Intercom-ID-#457

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/react": "^18.0.14"
   },
   "analyticsUrl": "https://analytics.mysterium.network",
-  "intercomAppId": "h7hlm9on",
+  "intercomAppId": "sjkeehf4",
   "pushyAppId": "5f23dc54d4786d7760003a71",
   "sentryDsn": "https://5c3208e8d6124f2db303a2d12c7f48b8@o136129.ingest.sentry.io/5222592",
   "electronWebpack": {


### PR DESCRIPTION
Intercom ID was successfully changed from package.json file:

from
"intercomAppId": "h7hlm9on" (Mystnodes Intercom)

to:
"intercomAppId": "sjkeehf4" (MysteriumVPN Intercom)